### PR TITLE
fix: formatting error in test with nightly compiler

### DIFF
--- a/src/lib.nr
+++ b/src/lib.nr
@@ -263,7 +263,7 @@ fn test_decode_max_byte() {
     assert(result == expected);
 }
 
-#[test(should_fail_with="DecodeError: invalid symbol 255, offset 0")]
+#[test(should_fail_with = "DecodeError: invalid symbol 255, offset 0")]
 fn test_decode_invalid() {
     let input: [u8; 1] = [255];
     let _: [u8; 0] = base64_decode(input);


### PR DESCRIPTION
# Description
This fixes a formatting error with the nightly compiler introduced by one of the tests from my last PR, sorry about that!

## Problem\*
Incorrect formatting in test with nightly compiler.

Resolves #17 

# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings. I used `nargo fmt` with nightly
