### PR TITLE
fix: add type declarations to globals

### DIFF
--- a/src/decoder.nr
+++ b/src/decoder.nr
@@ -1,9 +1,9 @@
 use super::defaults::BASE64_PADDING_CHAR;
 
-pub global STANDARD = Base64DecodeBE::new(true);
-pub global STANDARD_NO_PAD = Base64DecodeBE::new(false);
-pub global URL_SAFE = Base64DecodeBE::base64url(false);
-pub global URL_SAFE_WITH_PAD = Base64DecodeBE::base64url(true);
+pub global STANDARD: Base64DecodeBE = Base64DecodeBE::new(true);
+pub global STANDARD_NO_PAD: Base64DecodeBE = Base64DecodeBE::new(false);
+pub global URL_SAFE: Base64DecodeBE = Base64DecodeBE::base64url(false);
+pub global URL_SAFE_WITH_PAD: Base64DecodeBE = Base64DecodeBE::base64url(true);
 
 global INVALID_VALUE: u8 = 255;
 struct Base64DecodeBE {

--- a/src/encoder.nr
+++ b/src/encoder.nr
@@ -1,9 +1,9 @@
 use super::defaults::BASE64_PADDING_CHAR;
 
-pub global STANDARD = Base64EncodeBE::new(true);
-pub global STANDARD_NO_PAD = Base64EncodeBE::new(false);
-pub global URL_SAFE = Base64EncodeBE::base64url(false);
-pub global URL_SAFE_WITH_PAD = Base64EncodeBE::base64url(true);
+pub global STANDARD: Base64EncodeBE = Base64EncodeBE::new(true);
+pub global STANDARD_NO_PAD: Base64EncodeBE = Base64EncodeBE::new(false);
+pub global URL_SAFE: Base64EncodeBE = Base64EncodeBE::base64url(false);
+pub global URL_SAFE_WITH_PAD: Base64EncodeBE = Base64EncodeBE::base64url(true);
 
 struct Base64EncodeBE {
     // for some reason, if the lookup table is not defined in a struct, access costs are expensive and ROM tables aren't being used :/


### PR DESCRIPTION
# Description
fixed the issue with the undeclared types for globals. 
## Problem\*

Resolves <!-- Link to GitHub Issue -->

## Summary\*



## Additional Context



# PR Checklist\*

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.


BEGIN_COMMIT_OVERRIDE
fix: add type declarations to globals (#29)
END_COMMIT_OVERRIDE