### PR TITLE
chore: use `u32` for array indexes

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -17,12 +17,12 @@ jobs:
       - name: Install Nargo
         uses: noir-lang/noirup@v0.1.3
         with:
-          toolchain: 1.0.0-beta.3
+          toolchain: 1.0.0-beta.4
 
       - name: Install bb
         run: |
           npm install -g bbup
-          bbup -nv 1.0.0-beta.3
+          bbup -nv 1.0.0-beta.4
           sudo apt install libc++-dev
 
       - name: Build Noir benchmark programs

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install bb
         run: |
           npm install -g bbup
-          bbup -nv 1.0.0-beta.4
+          bbup -nv 1.0.0-beta.3
           sudo apt install libc++-dev
 
       - name: Build Noir benchmark programs

--- a/src/boundary_check.nr
+++ b/src/boundary_check.nr
@@ -1,5 +1,5 @@
-unconstrained fn __boundary_check<let Range: u32>(limit: u32) -> [u32; Range] {
-    let mut r: [u32; Range] = [0; Range];
+unconstrained fn __boundary_check<let Range: u32>(limit: u32) -> [Field; Range] {
+    let mut r: [Field; Range] = [0; Range];
     for i in limit..Range {
         r[i] = 1;
     }
@@ -14,11 +14,11 @@ unconstrained fn __boundary_check<let Range: u32>(limit: u32) -> [u32; Range] {
  *          This method efficiently generates such predicate values more efficiently than querying whether `i <= limit` at every iteration.
  *          Gate cost is 3 * Range
  **/
-pub fn boundary_check<let Range: u32>(limit: u32) -> [u32; Range] {
+pub fn boundary_check<let Range: u32>(limit: u32) -> [Field; Range] {
     // Safety: r contains claims about whether `r[i] >= limit`. the rest of this function checks this claim is correct
     let r = unsafe { __boundary_check(limit) };
 
-    let mut transition_index: Field = 0;
+    let mut transition_index = 0;
     // **
     // We have an array of Field elements `r` such that:
     // if i < limit, `r = 0`
@@ -37,12 +37,12 @@ pub fn boundary_check<let Range: u32>(limit: u32) -> [u32; Range] {
         for i in 0..Range - 1 {
             assert_eq(r[i] * r[i], r[i]);
             assert_eq(r[i] * r[i + 1], r[i]);
-            let idx = (r[i + 1] * (1 - r[i])) as Field * (i as Field + 1);
+            let idx = (r[i + 1] * (1 - r[i])) * (i as Field + 1);
             transition_index = transition_index + idx;
             std::as_witness(transition_index);
         }
         assert_eq(r[Range - 1] * r[Range - 1], r[Range - 1]);
-        transition_index = transition_index + (1 - r[Range - 1] as Field) * limit as Field;
+        transition_index = transition_index + (1 - r[Range - 1]) * limit as Field;
         assert(transition_index == limit as Field);
         r
     } else {

--- a/src/boundary_check.nr
+++ b/src/boundary_check.nr
@@ -1,5 +1,5 @@
-unconstrained fn __boundary_check<let Range: u32>(limit: u32) -> [Field; Range] {
-    let mut r: [Field; Range] = [0; Range];
+unconstrained fn __boundary_check<let Range: u32>(limit: u32) -> [u32; Range] {
+    let mut r: [u32; Range] = [0; Range];
     for i in limit..Range {
         r[i] = 1;
     }
@@ -14,11 +14,11 @@ unconstrained fn __boundary_check<let Range: u32>(limit: u32) -> [Field; Range] 
  *          This method efficiently generates such predicate values more efficiently than querying whether `i <= limit` at every iteration.
  *          Gate cost is 3 * Range
  **/
-pub fn boundary_check<let Range: u32>(limit: u32) -> [Field; Range] {
+pub fn boundary_check<let Range: u32>(limit: u32) -> [u32; Range] {
     // Safety: r contains claims about whether `r[i] >= limit`. the rest of this function checks this claim is correct
     let r = unsafe { __boundary_check(limit) };
 
-    let mut transition_index = 0;
+    let mut transition_index: Field = 0;
     // **
     // We have an array of Field elements `r` such that:
     // if i < limit, `r = 0`
@@ -37,12 +37,12 @@ pub fn boundary_check<let Range: u32>(limit: u32) -> [Field; Range] {
         for i in 0..Range - 1 {
             assert_eq(r[i] * r[i], r[i]);
             assert_eq(r[i] * r[i + 1], r[i]);
-            let idx = (r[i + 1] * (1 - r[i])) * (i as Field + 1);
+            let idx = (r[i + 1] * (1 - r[i])) as Field * (i as Field + 1);
             transition_index = transition_index + idx;
             std::as_witness(transition_index);
         }
         assert_eq(r[Range - 1] * r[Range - 1], r[Range - 1]);
-        transition_index = transition_index + (1 - r[Range - 1]) * limit as Field;
+        transition_index = transition_index + (1 - r[Range - 1] as Field) * limit as Field;
         assert(transition_index == limit as Field);
         r
     } else {

--- a/src/boundary_check.nr
+++ b/src/boundary_check.nr
@@ -15,10 +15,8 @@ unconstrained fn __boundary_check<let Range: u32>(limit: u32) -> [Field; Range] 
  *          Gate cost is 3 * Range
  **/
 pub fn boundary_check<let Range: u32>(limit: u32) -> [Field; Range] {
-    let r = unsafe {
-        //@safety r contains claims about whether `r[i] >= limit`. the rest of this function checks this claim is correct
-        __boundary_check(limit)
-    };
+    // Safety: r contains claims about whether `r[i] >= limit`. the rest of this function checks this claim is correct
+    let r = unsafe { __boundary_check(limit) };
 
     let mut transition_index = 0;
     // **

--- a/src/decoder.nr
+++ b/src/decoder.nr
@@ -340,7 +340,6 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                 } else {
                     decode_index = input_byte as Field + boundary_flags[offset] * 256;
                 }
-                decode_index.assert_max_bit_size::<32>();
                 let decode_index = decode_index as u32;
                 let decoded = if UseURLTable == 1 {
                     BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
@@ -409,7 +408,6 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
             } else {
                 decode_index = input_byte as Field + boundary_flags[offset] * 256;
             }
-            decode_index.assert_max_bit_size::<32>();
             let decode_index = decode_index as u32;
 
             let decoded = if UseURLTable == 1 {

--- a/src/decoder.nr
+++ b/src/decoder.nr
@@ -277,11 +277,11 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
     let input_length = input.len();
     let input = input.storage();
 
-    // boundary_flags = array of Field elements.
+    // boundary_flags = array of u32 elements.
     // if `i < input_length, boundary_flags[i] = 0`
     // if `i >= input_length, boundary_flags[i+1] = 1`
     // used as cheap(ish) predicates when iterating over bounded vector elements
-    let boundary_flags: [Field; InputElements] = boundary_check(input_length);
+    let boundary_flags: [u32; InputElements] = boundary_check(input_length);
     let mut result: [u8; OutputBytes] = [0; OutputBytes];
 
     let max_num_chunks = (InputElements / BASE64_ELEMENTS_PER_CHUNK)
@@ -299,7 +299,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                 let offset = i * BASE64_ELEMENTS_PER_CHUNK + j;
                 let input_byte = input[offset];
 
-                let mut decode_index: Field = 0;
+                let mut decode_index: u32 = 0;
                 if Pad == 1 {
                     let mut might_be_second_padding_char = 0;
                     let mut might_be_first_padding_char = 0;
@@ -326,8 +326,8 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                     // Case 1: we are at byte position `input.len() - 2` and `has_first_padding_byte_claim = true`
                     // Case 2: we are at byte position `input.len() - 1` and `has_second_padding_byte_claim = true`
                     let require_padding = might_be_first_padding_char
-                        * has_first_padding_byte_claim as Field
-                        + (might_be_second_padding_char * has_second_padding_byte_claim as Field);
+                        * has_first_padding_byte_claim as u32
+                        + (might_be_second_padding_char * has_second_padding_byte_claim as u32);
 
                     // The `decode_index` is used to map the input Base64 character into an output decoded character.
                     // We know `input_byte` is in the range 0-255 , so we use a size 768 lookup to handle the following 3 cases:
@@ -336,11 +336,10 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                     // Case 3 (index range 512-767): A claim has been made that a padding byte is present, and we are at the appropriate byte location to check this.
                     //                               The only valid input is BASE64_PADDING_CHAR, which decodes to 0. All other inputs return an error state
                     decode_index =
-                        input_byte as Field + boundary_flags[offset] * 256 + require_padding * 512;
+                        input_byte as u32 + boundary_flags[offset] * 256 + require_padding * 512;
                 } else {
-                    decode_index = input_byte as Field + boundary_flags[offset] * 256;
+                    decode_index = input_byte as u32 + boundary_flags[offset] * 256;
                 }
-                let decode_index = decode_index as u32;
                 let decoded = if UseURLTable == 1 {
                     BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
                 } else {
@@ -377,7 +376,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
             let offset = base64_offset + j;
             let input_byte = input[offset];
 
-            let mut decode_index: Field = 0;
+            let mut decode_index: u32 = 0;
             if Pad == 1 {
                 let mut might_be_second_padding_char = 0;
                 let mut might_be_first_padding_char = 0;
@@ -401,15 +400,13 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                 }
 
                 let require_padding = might_be_first_padding_char
-                    * has_first_padding_byte_claim as Field
-                    + (might_be_second_padding_char * has_second_padding_byte_claim as Field);
+                    * has_first_padding_byte_claim as u32
+                    + (might_be_second_padding_char * has_second_padding_byte_claim as u32);
                 decode_index =
-                    input_byte as Field + boundary_flags[offset] * 256 + require_padding * 512;
+                    input_byte as u32 + boundary_flags[offset] * 256 + require_padding * 512;
             } else {
-                decode_index = input_byte as Field + boundary_flags[offset] * 256;
+                decode_index = input_byte as u32 + boundary_flags[offset] * 256;
             }
-            let decode_index = decode_index as u32;
-
             let decoded = if UseURLTable == 1 {
                 BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
             } else {

--- a/src/decoder.nr
+++ b/src/decoder.nr
@@ -277,11 +277,11 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
     let input_length = input.len();
     let input = input.storage();
 
-    // boundary_flags = array of u32 elements.
+    // boundary_flags = array of Field elements.
     // if `i < input_length, boundary_flags[i] = 0`
     // if `i >= input_length, boundary_flags[i+1] = 1`
     // used as cheap(ish) predicates when iterating over bounded vector elements
-    let boundary_flags: [u32; InputElements] = boundary_check(input_length);
+    let boundary_flags: [Field; InputElements] = boundary_check(input_length);
     let mut result: [u8; OutputBytes] = [0; OutputBytes];
 
     let max_num_chunks = (InputElements / BASE64_ELEMENTS_PER_CHUNK)
@@ -299,7 +299,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                 let offset = i * BASE64_ELEMENTS_PER_CHUNK + j;
                 let input_byte = input[offset];
 
-                let mut decode_index: u32 = 0;
+                let mut decode_index: Field = 0;
                 if Pad == 1 {
                     let mut might_be_second_padding_char = 0;
                     let mut might_be_first_padding_char = 0;
@@ -326,8 +326,8 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                     // Case 1: we are at byte position `input.len() - 2` and `has_first_padding_byte_claim = true`
                     // Case 2: we are at byte position `input.len() - 1` and `has_second_padding_byte_claim = true`
                     let require_padding = might_be_first_padding_char
-                        * has_first_padding_byte_claim as u32
-                        + (might_be_second_padding_char * has_second_padding_byte_claim as u32);
+                        * has_first_padding_byte_claim as Field
+                        + (might_be_second_padding_char * has_second_padding_byte_claim as Field);
 
                     // The `decode_index` is used to map the input Base64 character into an output decoded character.
                     // We know `input_byte` is in the range 0-255 , so we use a size 768 lookup to handle the following 3 cases:
@@ -336,10 +336,11 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                     // Case 3 (index range 512-767): A claim has been made that a padding byte is present, and we are at the appropriate byte location to check this.
                     //                               The only valid input is BASE64_PADDING_CHAR, which decodes to 0. All other inputs return an error state
                     decode_index =
-                        input_byte as u32 + boundary_flags[offset] * 256 + require_padding * 512;
+                        input_byte as Field + boundary_flags[offset] * 256 + require_padding * 512;
                 } else {
-                    decode_index = input_byte as u32 + boundary_flags[offset] * 256;
+                    decode_index = input_byte as Field + boundary_flags[offset] * 256;
                 }
+                let decode_index = decode_index as u32;
                 let decoded = if UseURLTable == 1 {
                     BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
                 } else {
@@ -376,7 +377,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
             let offset = base64_offset + j;
             let input_byte = input[offset];
 
-            let mut decode_index: u32 = 0;
+            let mut decode_index: Field = 0;
             if Pad == 1 {
                 let mut might_be_second_padding_char = 0;
                 let mut might_be_first_padding_char = 0;
@@ -400,13 +401,15 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                 }
 
                 let require_padding = might_be_first_padding_char
-                    * has_first_padding_byte_claim as u32
-                    + (might_be_second_padding_char * has_second_padding_byte_claim as u32);
+                    * has_first_padding_byte_claim as Field
+                    + (might_be_second_padding_char * has_second_padding_byte_claim as Field);
                 decode_index =
-                    input_byte as u32 + boundary_flags[offset] * 256 + require_padding * 512;
+                    input_byte as Field + boundary_flags[offset] * 256 + require_padding * 512;
             } else {
-                decode_index = input_byte as u32 + boundary_flags[offset] * 256;
+                decode_index = input_byte as Field + boundary_flags[offset] * 256;
             }
+            let decode_index = decode_index as u32;
+
             let decoded = if UseURLTable == 1 {
                 BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
             } else {

--- a/src/decoder.nr
+++ b/src/decoder.nr
@@ -183,12 +183,12 @@ fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let UseURLT
                 };
                 validity_check += decoded;
                 slice += decoded as Field;
+                // Safety: get a sensible error message out if the decoding is invalid.
+                // Note that we *constrain* the encoding is correct by performing a range check on `validity_check`
+                // If the decoding is invalid, `decoded = -2^{32}`. We add up all `decoded` values and apply a 32-bit range check.
+                // Given all valid encodings are 8-bit, as long as the input length is less than 2^24 bytes, it is not possible to
+                // underflow validity_check with an invalid encoding, and then overflow again by adding up valid encodings
                 unsafe {
-                    //@safety get a sensible error message out if the decoding is invalid.
-                    // Note that we *constrain* the encoding is correct by performing a range check on `validity_check`
-                    // If the decoding is invalid, `decoded = -2^{32}`. We add up all `decoded` values and apply a 32-bit range check.
-                    // Given all valid encodings are 8-bit, as long as the input length is less than 2^24 bytes, it is not possible to
-                    // underflow validity_check with an invalid encoding, and then overflow again by adding up valid encodings
                     __validate_decoded(decoded, input_byte, offset);
                 }
             }
@@ -220,12 +220,12 @@ fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let UseURLT
             };
             validity_check += decoded;
             slice += decoded as Field;
+            // Safety: get a sensible error message out if the decoding is invalid.
+            // Note that we *constrain* the encoding is correct by performing a range check on `validity_check`
+            // If the decoding is invalid, `decoded = -2^{32}`. We add up all `decoded` values and apply a 32-bit range check.
+            // Given all valid encodings are 8-bit, as long as the input length is less than 2^24 bytes, it is not possible to
+            // underflow validity_check with an invalid encoding, and then overflow again by adding up valid encodings
             unsafe {
-                //@safety get a sensible error message out if the decoding is invalid.
-                // Note that we *constrain* the encoding is correct by performing a range check on `validity_check`
-                // If the decoding is invalid, `decoded = -2^{32}`. We add up all `decoded` values and apply a 32-bit range check.
-                // Given all valid encodings are 8-bit, as long as the input length is less than 2^24 bytes, it is not possible to
-                // underflow validity_check with an invalid encoding, and then overflow again by adding up valid encodings
                 __validate_decoded(decoded, input_byte, offset);
             }
         }
@@ -256,9 +256,9 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
 ) -> BoundedVec<u8, OutputBytes> {
     // We don't know how many padding bytes the input string contains - we use an unconstrained fn to return a *claim* that we will later validate
     let (has_first_padding_byte_claim, has_second_padding_byte_claim) = if (Pad == 1) {
+        // Safety: get claims about whether the bytes input[input.len() - 2] and input[input.len() - 1] are padding chars
+        // we validate this later on by requiring these characters equal BASE64_PADDING_CHAR by looking up BASE64_DECODE_BE_VAR_TABLE
         unsafe {
-            //@safety get claims about whether the bytes input[input.len() - 2] and input[input.len() - 1] are padding chars
-            // we validate this later on by requiring these characters equal BASE64_PADDING_CHAR by looking up BASE64_DECODE_BE_VAR_TABLE
             crate::decoder::__get_num_padding_chars_var::<InputElements>(input)
         }
     } else {
@@ -346,12 +346,12 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
 
                 validity_check += decoded;
                 slice += decoded;
+                // Safety: get a sensible error message out if the decoding is invalid.
+                // Note that we *constrain* the encoding is correct by performing a range check on `validity_check`
+                // If the decoding is invalid, `decoded = -2^{32}`. We add up all `decoded` values and apply a 32-bit range check.
+                // Given all valid encodings are 8-bit, as long as the input length is less than 2^24 bytes, it is not possible to
+                // underflow validity_check with an invalid encoding, and then overflow again by adding up valid encodings
                 unsafe {
-                    //@safety get a sensible error message out if the decoding is invalid.
-                    // Note that we *constrain* the encoding is correct by performing a range check on `validity_check`
-                    // If the decoding is invalid, `decoded = -2^{32}`. We add up all `decoded` values and apply a 32-bit range check.
-                    // Given all valid encodings are 8-bit, as long as the input length is less than 2^24 bytes, it is not possible to
-                    // underflow validity_check with an invalid encoding, and then overflow again by adding up valid encodings
                     __validate_decoded(decoded, input_byte, offset);
                 }
             }
@@ -410,12 +410,12 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
             } else {
                 BASE64_DECODE_BE_VAR_TABLE[decode_index]
             };
+            // Safety: get a sensible error message out if the decoding is invalid.
+            // Note that we *constrain* the encoding is correct by performing a range check on `validity_check`
+            // If the decoding is invalid, `decoded = -2^{32}`. We add up all `decoded` values and apply a 32-bit range check.
+            // Given all valid encodings are 8-bit, as long as the input length is less than 2^24 bytes, it is not possible to
+            // underflow validity_check with an invalid encoding, and then overflow again by adding up valid encodings
             unsafe {
-                //@safety get a sensible error message out if the decoding is invalid.
-                // Note that we *constrain* the encoding is correct by performing a range check on `validity_check`
-                // If the decoding is invalid, `decoded = -2^{32}`. We add up all `decoded` values and apply a 32-bit range check.
-                // Given all valid encodings are 8-bit, as long as the input length is less than 2^24 bytes, it is not possible to
-                // underflow validity_check with an invalid encoding, and then overflow again by adding up valid encodings
                 __validate_decoded(decoded, input_byte, offset);
             }
             validity_check += decoded;

--- a/src/decoder.nr
+++ b/src/decoder.nr
@@ -175,11 +175,12 @@ fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let UseURLT
             for j in 0..BASE64_ELEMENTS_PER_CHUNK {
                 slice *= 64;
                 let offset = i * BASE64_ELEMENTS_PER_CHUNK + j;
-                let input_byte = input[offset];
+                let input_byte: u8 = input[offset];
+                let index = input_byte as u32;
                 let decoded = if UseURLTable == 1 {
-                    BASE64_DECODE_BE_URL_TABLE[input_byte]
+                    BASE64_DECODE_BE_URL_TABLE[index]
                 } else {
-                    BASE64_DECODE_BE_TABLE[input_byte]
+                    BASE64_DECODE_BE_TABLE[index]
                 };
                 validity_check += decoded;
                 slice += decoded as Field;
@@ -212,11 +213,12 @@ fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let UseURLT
         for j in 0..base64_elements_in_final_chunk {
             slice *= 64;
             let offset = base64_offset + j;
-            let input_byte = input[offset];
+            let input_byte: u8 = input[offset];
+            let index = input_byte as u32;
             let decoded = if UseURLTable == 1 {
-                BASE64_DECODE_BE_URL_TABLE[input_byte]
+                BASE64_DECODE_BE_URL_TABLE[index]
             } else {
-                BASE64_DECODE_BE_TABLE[input_byte]
+                BASE64_DECODE_BE_TABLE[index]
             };
             validity_check += decoded;
             slice += decoded as Field;
@@ -338,6 +340,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                 } else {
                     decode_index = input_byte as Field + boundary_flags[offset] * 256;
                 }
+                let decode_index = decode_index as u32;
                 let decoded = if UseURLTable == 1 {
                     BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
                 } else {
@@ -405,6 +408,8 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
             } else {
                 decode_index = input_byte as Field + boundary_flags[offset] * 256;
             }
+            let decode_index = decode_index as u32;
+
             let decoded = if UseURLTable == 1 {
                 BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
             } else {

--- a/src/decoder.nr
+++ b/src/decoder.nr
@@ -340,6 +340,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                 } else {
                     decode_index = input_byte as Field + boundary_flags[offset] * 256;
                 }
+                decode_index.assert_max_bit_size::<32>();
                 let decode_index = decode_index as u32;
                 let decoded = if UseURLTable == 1 {
                     BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
@@ -408,6 +409,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
             } else {
                 decode_index = input_byte as Field + boundary_flags[offset] * 256;
             }
+            decode_index.assert_max_bit_size::<32>();
             let decode_index = decode_index as u32;
 
             let decoded = if UseURLTable == 1 {

--- a/src/encoder.nr
+++ b/src/encoder.nr
@@ -8,8 +8,8 @@ use crate::tables::{
 pub use crate::boundary_check::boundary_check;
 
 global CONVERT_MODULO3_TO_PADDING_BYTES: [u32; 3] = [0, 2, 1];
-global PAD_1: [Field; 3] = [0, 1, 1];
-global PAD_2: [Field; 3] = [0, 1, 0];
+global PAD_1: [u32; 3] = [0, 1, 1];
+global PAD_2: [u32; 3] = [0, 1, 0];
 
 /// Encoder methods that use the standard Base64 Alphabet (base64) specified in RFC 4648
 /// (https://datatracker.ietf.org/doc/html/rfc4648#section-4)
@@ -134,7 +134,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
 
     // Get an array of Field elements where boundary_flags[i] = 0 if i < encoded_length, otherwise i = 1.
     // We use this array to determine if the result array should contain a valid Base64 encoded value, 0 or if an error state has been reached
-    let boundary_flags: [Field; ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))] =
+    let boundary_flags: [u32; ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))] =
         boundary_check(encoded_length);
 
     // Using 2 lookups is slightly cheaper than figuring out if the 1st/2nd padding byte is set from the padding length param... I think?
@@ -153,7 +153,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
     // Note: if `boundary_flags[0] = 1`, the `BASE64_ENCODE_BE_VAR_TABLE` lookup will output 0.
     // Note: `MAX_INPUT_LEN` is known at compile time so this `if` statement should not incur constraints.
     if MAX_INPUT_LEN > 0 {
-        let index = (raw[0] as Field + boundary_flags[0] * 64) as u32;
+        let index = raw[0] as u32 + boundary_flags[0] * 64;
         result_arr[0] = BASE64_ENCODE_BE_VAR_TABLE[index] as u8;
     }
 
@@ -162,12 +162,12 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
         let exceed_length = boundary_flags[i];
         // hit_limit = we are at the first location where a padding Base64 character *could* be enerated
 
-        let mut encoding_index: Field = 0;
+        let mut encoding_index: u32 = 0;
 
         if HasPadding == 1 {
-            let hit_limit: Field = (1 - boundary_flags[i - 1]) * boundary_flags[i];
+            let hit_limit: u32 = (1 - boundary_flags[i - 1]) * boundary_flags[i];
             // We need to write a padding byte if `i == encoding_length` and `has_first_padding_byte == 1`
-            let write_first_padding_byte: Field = hit_limit * has_first_padding_byte;
+            let write_first_padding_byte: u32 = hit_limit * has_first_padding_byte;
             // We need to write a padding byte if `i == encoding_length + 1` and `has_second_padding_byte == 1`
             let write_second_padding_byte =
                 previous_was_first_padding_byte * has_second_padding_byte;
@@ -183,7 +183,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
             //      outcome: if `raw[i] = 0`, the returned value is BASE64_PADDING_CHAR. All other inputs for `raw[i]` return an error state
             // Note: due to how they are constructed, it is not possible for both `write_first_padding_byte` and `write_second_padding_byte` to equal 1.
             //       Similarly, it is not possible for `exceed_length = 0` and either of `write_first_padding_byte` or `write_second_padding_byte` to equal 1.
-            encoding_index = raw[i] as Field
+            encoding_index = raw[i] as u32
                 + (exceed_length + write_first_padding_byte + write_second_padding_byte) * 64;
             previous_was_first_padding_byte = write_first_padding_byte;
         } else {
@@ -194,9 +194,8 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
             // CASE 2: `exceed_length = 1`
             //      outcome: if `raw[i] = 0`, the returned value is 0. All other inputs for `raw[i]` return an error state
 
-            encoding_index = raw[i] as Field + (exceed_length * 64);
+            encoding_index = raw[i] as u32 + (exceed_length * 64);
         }
-        let encoding_index = encoding_index as u32;
 
         // Note: this `if` condition is known at compile time so should not incur additional constraints
         let token: u8 = if UseURLTable == 1 {

--- a/src/encoder.nr
+++ b/src/encoder.nr
@@ -85,10 +85,11 @@ fn encode_elements<let InputElements: u32, let UseUrlTable: u1>(
     let mut result: [u8; InputElements] = [0; InputElements];
 
     for i in 0..InputElements {
+        let index = input[i] as u32;
         let token: u8 = if UseUrlTable == 1 {
-            BASE64URL_ENCODE_BE_TABLE[input[i]]
+            BASE64URL_ENCODE_BE_TABLE[index]
         } else {
-            BASE64_ENCODE_BE_TABLE[input[i]]
+            BASE64_ENCODE_BE_TABLE[index]
         };
         result[i] = token as u8;
     }
@@ -152,7 +153,8 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
     // Note: if `boundary_flags[0] = 1`, the `BASE64_ENCODE_BE_VAR_TABLE` lookup will output 0.
     // Note: `MAX_INPUT_LEN` is known at compile time so this `if` statement should not incur constraints.
     if MAX_INPUT_LEN > 0 {
-        result_arr[0] = BASE64_ENCODE_BE_VAR_TABLE[raw[0] as Field + boundary_flags[0] * 64] as u8;
+        let index = (raw[0] as Field + boundary_flags[0] * 64) as u32;
+        result_arr[0] = BASE64_ENCODE_BE_VAR_TABLE[index] as u8;
     }
 
     let mut previous_was_first_padding_byte = 0;
@@ -194,6 +196,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
 
             encoding_index = raw[i] as Field + (exceed_length * 64);
         }
+        let encoding_index = encoding_index as u32;
 
         // Note: this `if` condition is known at compile time so should not incur additional constraints
         let token: u8 = if UseURLTable == 1 {

--- a/src/encoder.nr
+++ b/src/encoder.nr
@@ -153,10 +153,8 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
     // Note: if `boundary_flags[0] = 1`, the `BASE64_ENCODE_BE_VAR_TABLE` lookup will output 0.
     // Note: `MAX_INPUT_LEN` is known at compile time so this `if` statement should not incur constraints.
     if MAX_INPUT_LEN > 0 {
-        let index = raw[0] as Field + boundary_flags[0] * 64;
-        index.assert_max_bit_size::<32>();
-        let index = index as u32;
-        result_arr[0] = BASE64_ENCODE_BE_VAR_TABLE[index];
+        let index = (raw[0] as Field + boundary_flags[0] * 64) as u32;
+        result_arr[0] = BASE64_ENCODE_BE_VAR_TABLE[index] as u8;
     }
 
     let mut previous_was_first_padding_byte = 0;
@@ -198,7 +196,6 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
 
             encoding_index = raw[i] as Field + (exceed_length * 64);
         }
-        encoding_index.assert_max_bit_size::<32>();
         let encoding_index = encoding_index as u32;
 
         // Note: this `if` condition is known at compile time so should not incur additional constraints

--- a/src/encoder.nr
+++ b/src/encoder.nr
@@ -8,8 +8,8 @@ use crate::tables::{
 pub use crate::boundary_check::boundary_check;
 
 global CONVERT_MODULO3_TO_PADDING_BYTES: [u32; 3] = [0, 2, 1];
-global PAD_1: [u32; 3] = [0, 1, 1];
-global PAD_2: [u32; 3] = [0, 1, 0];
+global PAD_1: [Field; 3] = [0, 1, 1];
+global PAD_2: [Field; 3] = [0, 1, 0];
 
 /// Encoder methods that use the standard Base64 Alphabet (base64) specified in RFC 4648
 /// (https://datatracker.ietf.org/doc/html/rfc4648#section-4)
@@ -134,7 +134,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
 
     // Get an array of Field elements where boundary_flags[i] = 0 if i < encoded_length, otherwise i = 1.
     // We use this array to determine if the result array should contain a valid Base64 encoded value, 0 or if an error state has been reached
-    let boundary_flags: [u32; ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))] =
+    let boundary_flags: [Field; ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))] =
         boundary_check(encoded_length);
 
     // Using 2 lookups is slightly cheaper than figuring out if the 1st/2nd padding byte is set from the padding length param... I think?
@@ -153,7 +153,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
     // Note: if `boundary_flags[0] = 1`, the `BASE64_ENCODE_BE_VAR_TABLE` lookup will output 0.
     // Note: `MAX_INPUT_LEN` is known at compile time so this `if` statement should not incur constraints.
     if MAX_INPUT_LEN > 0 {
-        let index = raw[0] as u32 + boundary_flags[0] * 64;
+        let index = (raw[0] as Field + boundary_flags[0] * 64) as u32;
         result_arr[0] = BASE64_ENCODE_BE_VAR_TABLE[index] as u8;
     }
 
@@ -162,12 +162,12 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
         let exceed_length = boundary_flags[i];
         // hit_limit = we are at the first location where a padding Base64 character *could* be enerated
 
-        let mut encoding_index: u32 = 0;
+        let mut encoding_index: Field = 0;
 
         if HasPadding == 1 {
-            let hit_limit: u32 = (1 - boundary_flags[i - 1]) * boundary_flags[i];
+            let hit_limit: Field = (1 - boundary_flags[i - 1]) * boundary_flags[i];
             // We need to write a padding byte if `i == encoding_length` and `has_first_padding_byte == 1`
-            let write_first_padding_byte: u32 = hit_limit * has_first_padding_byte;
+            let write_first_padding_byte: Field = hit_limit * has_first_padding_byte;
             // We need to write a padding byte if `i == encoding_length + 1` and `has_second_padding_byte == 1`
             let write_second_padding_byte =
                 previous_was_first_padding_byte * has_second_padding_byte;
@@ -183,7 +183,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
             //      outcome: if `raw[i] = 0`, the returned value is BASE64_PADDING_CHAR. All other inputs for `raw[i]` return an error state
             // Note: due to how they are constructed, it is not possible for both `write_first_padding_byte` and `write_second_padding_byte` to equal 1.
             //       Similarly, it is not possible for `exceed_length = 0` and either of `write_first_padding_byte` or `write_second_padding_byte` to equal 1.
-            encoding_index = raw[i] as u32
+            encoding_index = raw[i] as Field
                 + (exceed_length + write_first_padding_byte + write_second_padding_byte) * 64;
             previous_was_first_padding_byte = write_first_padding_byte;
         } else {
@@ -194,8 +194,9 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
             // CASE 2: `exceed_length = 1`
             //      outcome: if `raw[i] = 0`, the returned value is 0. All other inputs for `raw[i]` return an error state
 
-            encoding_index = raw[i] as u32 + (exceed_length * 64);
+            encoding_index = raw[i] as Field + (exceed_length * 64);
         }
+        let encoding_index = encoding_index as u32;
 
         // Note: this `if` condition is known at compile time so should not incur additional constraints
         let token: u8 = if UseURLTable == 1 {

--- a/src/encoder.nr
+++ b/src/encoder.nr
@@ -153,8 +153,10 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
     // Note: if `boundary_flags[0] = 1`, the `BASE64_ENCODE_BE_VAR_TABLE` lookup will output 0.
     // Note: `MAX_INPUT_LEN` is known at compile time so this `if` statement should not incur constraints.
     if MAX_INPUT_LEN > 0 {
-        let index = (raw[0] as Field + boundary_flags[0] * 64) as u32;
-        result_arr[0] = BASE64_ENCODE_BE_VAR_TABLE[index] as u8;
+        let index = raw[0] as Field + boundary_flags[0] * 64;
+        index.assert_max_bit_size::<32>();
+        let index = index as u32;
+        result_arr[0] = BASE64_ENCODE_BE_VAR_TABLE[index];
     }
 
     let mut previous_was_first_padding_byte = 0;
@@ -196,6 +198,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
 
             encoding_index = raw[i] as Field + (exceed_length * 64);
         }
+        encoding_index.assert_max_bit_size::<32>();
         let encoding_index = encoding_index as u32;
 
         // Note: this `if` condition is known at compile time so should not incur additional constraints


### PR DESCRIPTION
# Description

## Problem


## Summary

I considered changing some variables, and some methods, to be `u32` instead of `Field` but my guess is that they are `Field` for efficiency reasons. Also, looking at the code, these `Field` values will be in the `0..u32::MAX` range (for example what `__boundary_check` returns).

## Additional Context

Also fixes some safety comments.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.


BEGIN_COMMIT_OVERRIDE
fix: use u32 for array indexes (#41)
END_COMMIT_OVERRIDE