### PR TITLE
fix: don't use private `to_be_radix` from stdlib

### DIFF
--- a/src/encoder.nr
+++ b/src/encoder.nr
@@ -1,3 +1,5 @@
+mod to_be_radix;
+
 use super::defaults::{BASE64_ELEMENTS_PER_CHUNK, BASE64_PADDING_CHAR, BYTES_PER_CHUNK};
 
 use crate::tables::{
@@ -6,6 +8,7 @@ use crate::tables::{
 };
 
 pub use crate::boundary_check::boundary_check;
+use to_be_radix::to_be_radix_64;
 
 global CONVERT_MODULO3_TO_PADDING_BYTES: [u32; 3] = [0, 2, 1];
 global PAD_1: [Field; 3] = [0, 1, 1];
@@ -105,7 +108,8 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
     ) -> BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))> {
     assert((HasPadding == 0) | (HasPadding == 1), "invalid HasPadding parameter");
     // The max number of output Base64 values can be derived from the max input size
-    let mut result_arr: [u8; ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))] = [
+    let mut result_arr
+        : [u8; ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))] = [
         0; ((MAX_INPUT_LEN * 8) / 6)
             + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2))
             + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))
@@ -213,7 +217,8 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
 
     // we can use `from_parts_unchecked` here because the table BASE64_ENCODE_BE_VAR_TABLE (and it's URL equivalent)
     // will produce an error if a nonzero input is given past `final_length`
-    let mut r: BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))> =
+    let mut r
+        : BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))> =
         BoundedVec::from_parts_unchecked(result_arr, final_length);
 
     r
@@ -259,7 +264,7 @@ fn split_into_six_bit_chunks<let InputBytes: u32, let OutputElements: u32, let H
                 slice += input[i * BYTES_PER_CHUNK + j] as Field;
             }
             // extract the 6-bit values from the Field element
-            let slice_base64_chunks: [u8; BASE64_ELEMENTS_PER_CHUNK] = slice.to_be_radix(64);
+            let slice_base64_chunks: [u8; BASE64_ELEMENTS_PER_CHUNK] = to_be_radix_64(slice);
             for j in 0..BASE64_ELEMENTS_PER_CHUNK {
                 result[i * BASE64_ELEMENTS_PER_CHUNK + j] = slice_base64_chunks[j];
             }
@@ -282,7 +287,7 @@ fn split_into_six_bit_chunks<let InputBytes: u32, let OutputElements: u32, let H
         }
 
         // extract the 6-bit values from the Field element
-        let slice_base64_chunks: [u8; BASE64_ELEMENTS_PER_CHUNK] = slice.to_be_radix(64);
+        let slice_base64_chunks: [u8; BASE64_ELEMENTS_PER_CHUNK] = to_be_radix_64(slice);
         for i in 0..num_elements_in_final_chunk {
             // If padding is enabled, we can skip setting the last `non_padded_output_length` chars
             // N.B. if statement is compile time so shouldn't add c onstraints

--- a/src/encoder.nr
+++ b/src/encoder.nr
@@ -108,8 +108,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
     ) -> BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))> {
     assert((HasPadding == 0) | (HasPadding == 1), "invalid HasPadding parameter");
     // The max number of output Base64 values can be derived from the max input size
-    let mut result_arr
-        : [u8; ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))] = [
+    let mut result_arr: [u8; ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))] = [```
         0; ((MAX_INPUT_LEN * 8) / 6)
             + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2))
             + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))
@@ -217,8 +216,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
 
     // we can use `from_parts_unchecked` here because the table BASE64_ENCODE_BE_VAR_TABLE (and it's URL equivalent)
     // will produce an error if a nonzero input is given past `final_length`
-    let mut r
-        : BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))> =
+    let mut r: BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))> =
         BoundedVec::from_parts_unchecked(result_arr, final_length);
 
     r

--- a/src/encoder.nr
+++ b/src/encoder.nr
@@ -108,7 +108,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
     ) -> BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))> {
     assert((HasPadding == 0) | (HasPadding == 1), "invalid HasPadding parameter");
     // The max number of output Base64 values can be derived from the max input size
-    let mut result_arr: [u8; ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))] = [```
+    let mut result_arr: [u8; ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))] = [
         0; ((MAX_INPUT_LEN * 8) / 6)
             + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2))
             + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))

--- a/src/encoder/to_be_radix.nr
+++ b/src/encoder/to_be_radix.nr
@@ -1,0 +1,64 @@
+/// Decomposes a Field into base-64 values, big-endian.
+///
+/// Example:
+///
+/// ```noir
+/// assert_eq(to_be_radix_64::<2>(42), [0, 42]);
+/// assert_eq(to_be_radix_64::<2>(1 * 64 + 2), [1, 2]);
+/// assert_eq(to_be_radix_64::<3>(3 * 64 * 64 + 2 * 64 + 1), [3, 2, 1]);
+/// ```
+pub(crate) fn to_be_radix_64<let N: u32>(x: Field) -> [u8; N] {
+    // For convenience, we get bytes in little-endian to traverse them from the beginning.
+    // Because the base64 decomposition has more elements than the bytes decomposition,
+    // it turns out `N * 3 / 4` is enough bytes for this.
+    let bytes = x.to_le_bytes::<N * 3 / 4>();
+    let mut result = [0; N];
+
+    // For the result, we start writing from the end.
+    let mut result_index = N - 1;
+
+    // For the first byte we can simply do `byte % 64` for the low part
+    // and `byte / 64` for the high part.
+    // However, the second byte equals to 256 times its value. That's 4 times 64,
+    // so we multiply the byte value by 4.
+    // For the third byte, it equals 256*256 times its value. That's 16 times 64*64,
+    // so we multiply the byte value by 16 this time.
+    // For the fourth byte, it equals 256*256*256 times its value. That's 64 times 64*64*64
+    // so here we just need to start writing to the result position shifting by one.
+    // And so on...
+    let mut multiplier = 1;
+
+    for index in 0..bytes.len() {
+        let byte = bytes[index] as u16 * multiplier;
+
+        result[result_index] += (byte % 64) as u8;
+        result[result_index - 1] += (byte / 64) as u8;
+        result_index -= 1;
+
+        multiplier *= 4;
+        if (multiplier == 64) & (index != bytes.len() - 1) {
+            multiplier = 1;
+            result_index -= 1;
+        }
+    }
+
+    result
+}
+
+#[test]
+fn test_to_be_radix_64(field: Field) {
+    let bytes = to_be_radix_64::<43>(field);
+
+    // Compute the field value from the bytes decomposition
+    // and check that it ends up being the same as the original value.
+    let mut result = 0;
+    let mut multiplier = 1;
+    for index in 0..bytes.len() {
+        let index = bytes.len() - index - 1;
+        let byte = bytes[index];
+        let value = byte as Field * multiplier;
+        result += value;
+        multiplier *= 64;
+    }
+    assert_eq(field, result);
+}

--- a/src/encoder/to_be_radix.nr
+++ b/src/encoder/to_be_radix.nr
@@ -12,10 +12,46 @@ pub(crate) fn to_be_radix_64<let N: u32>(x: Field) -> [u8; N] {
     // Because the base64 decomposition has more elements than the bytes decomposition,
     // it turns out `N * 3 / 4` is enough bytes for this.
     let bytes = x.to_le_bytes::<N * 3 / 4>();
-    let mut result = [0; N];
+
+    // Safety: we check this below
+    let result = unsafe { to_be_radix_64_decomposition(bytes) };
+
+    let mut byte_index = 0;
+
+    for index in 0..result.len() {
+        let result_index = result.len() - index - 1;
+        let index_mod_4 = index % 4;
+
+        let byte0 = bytes[byte_index] as u16;
+        let byte1 = bytes[byte_index + 1] as u16;
+        let byte2 = if byte_index + 2 < bytes.len() {
+            bytes[byte_index + 2] as u16
+        } else {
+            0
+        };
+
+        // The math here comes from reversing the math in `to_be_radix_64_decomposition`
+        let result = result[result_index] as u16;
+        if index_mod_4 == 0 {
+            assert_eq(result, byte0 % 64);
+        } else if index_mod_4 == 1 {
+            assert_eq(result, byte0 / 64 + byte1 * 4 % 64);
+        } else if index_mod_4 == 2 {
+            assert_eq(result, byte1 * 4 / 64 + byte2 * 16 % 64);
+        } else {
+            assert_eq(result, byte2 * 16 / 64);
+            byte_index += 3;
+        }
+    }
+
+    result
+}
+
+unconstrained fn to_be_radix_64_decomposition<let N: u32, let M: u32>(bytes: [u8; N]) -> [u8; M] {
+    let mut result = [0; M];
 
     // For the result, we start writing from the end.
-    let mut result_index = N - 1;
+    let mut result_index = M - 1;
 
     // For the first byte we can simply do `byte % 64` for the low part
     // and `byte / 64` for the high part.

--- a/src/encoder/to_be_radix.nr
+++ b/src/encoder/to_be_radix.nr
@@ -16,31 +16,30 @@ pub(crate) fn to_be_radix_64<let N: u32>(x: Field) -> [u8; N] {
     // Safety: we check this below
     let result = unsafe { to_be_radix_64_decomposition(bytes) };
 
-    let mut byte_index = 0;
-
     for index in 0..result.len() {
         let result_index = result.len() - index - 1;
         let index_mod_4 = index % 4;
+        let byte_index = (index / 4) * 3;
 
-        let byte0 = bytes[byte_index] as u16;
-        let byte1 = bytes[byte_index + 1] as u16;
+        let byte0 = bytes[byte_index];
+        let byte1 = bytes[byte_index + 1];
         let byte2 = if byte_index + 2 < bytes.len() {
-            bytes[byte_index + 2] as u16
+            bytes[byte_index + 2]
         } else {
             0
         };
 
         // The math here comes from reversing the math in `to_be_radix_64_decomposition`
-        let result = result[result_index] as u16;
+        // We also use the fact that `(x * y) % z` is the same as `((x % z) * (y % z)) % z`.
+        let result = result[result_index];
         if index_mod_4 == 0 {
             assert_eq(result, byte0 % 64);
         } else if index_mod_4 == 1 {
-            assert_eq(result, byte0 / 64 + byte1 * 4 % 64);
+            assert_eq(result, byte0 / 64 + ((byte1 % 64) * 4) % 64);
         } else if index_mod_4 == 2 {
-            assert_eq(result, byte1 * 4 / 64 + byte2 * 16 % 64);
+            assert_eq(result, byte1 / 16 + ((((byte2 % 64) * 4) % 64) * 4) % 64);
         } else {
-            assert_eq(result, byte2 * 16 / 64);
-            byte_index += 3;
+            assert_eq(result, byte2 / 4);
         }
     }
 


### PR DESCRIPTION
# Description

## Problem

Resolves #46

## Summary

## Additional Context

I think this is my first Noir contribution that involves an algorithm, and a math algorithm in this case, so let me know if I missed something.

# PR Checklist

- [x] I have tested the changes locally.
- [x] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
