### PR TITLE
fix: Remove usage of `u1` type

### DIFF
--- a/src/decoder.nr
+++ b/src/decoder.nr
@@ -14,13 +14,13 @@ pub mod Base64DecodeBE {
     pub fn decode<let InputBytes: u32, let OutputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; OutputBytes] {
-        crate::decoder::decode::<InputBytes, OutputBytes, 1_u1, 0_u1>(input)
+        crate::decoder::decode::<InputBytes, OutputBytes, true, false>(input)
     }
 
     pub fn decode_var<let MaxInputBytes: u32, let MaxOutputBytes: u32>(
         input: BoundedVec<u8, MaxInputBytes>,
     ) -> BoundedVec<u8, MaxOutputBytes> {
-        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, 1_u1, 0_u1>(input)
+        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, true, false>(input)
     }
 }
 
@@ -30,13 +30,13 @@ pub mod Base64DecodeBENoPad {
     pub fn decode<let InputBytes: u32, let OutputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; OutputBytes] {
-        crate::decoder::decode::<InputBytes, OutputBytes, 0_u1, 0_u1>(input)
+        crate::decoder::decode::<InputBytes, OutputBytes, false, false>(input)
     }
 
     pub fn decode_var<let MaxInputBytes: u32, let MaxOutputBytes: u32>(
         input: BoundedVec<u8, MaxInputBytes>,
     ) -> BoundedVec<u8, MaxOutputBytes> {
-        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, 0_u1, 0_u1>(input)
+        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, false, false>(input)
     }
 }
 
@@ -46,13 +46,13 @@ pub mod Base64DecodeBEUrlSafe {
     pub fn decode<let InputBytes: u32, let OutputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; OutputBytes] {
-        crate::decoder::decode::<InputBytes, OutputBytes, 0_u1, 1_u1>(input)
+        crate::decoder::decode::<InputBytes, OutputBytes, false, true>(input)
     }
 
     pub fn decode_var<let MaxInputBytes: u32, let MaxOutputBytes: u32>(
         input: BoundedVec<u8, MaxInputBytes>,
     ) -> BoundedVec<u8, MaxOutputBytes> {
-        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, 0_u1, 1_u1>(input)
+        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, false, true>(input)
     }
 }
 
@@ -62,13 +62,13 @@ pub mod Base64DecodeBEUrlSafeWithPad {
     pub fn decode<let InputBytes: u32, let OutputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; OutputBytes] {
-        crate::decoder::decode::<InputBytes, OutputBytes, 1_u1, 1_u1>(input)
+        crate::decoder::decode::<InputBytes, OutputBytes, true, true>(input)
     }
 
     pub fn decode_var<let MaxInputBytes: u32, let MaxOutputBytes: u32>(
         input: BoundedVec<u8, MaxInputBytes>,
     ) -> BoundedVec<u8, MaxOutputBytes> {
-        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, 1_u1, 1_u1>(input)
+        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, true, true>(input)
     }
 }
 
@@ -111,7 +111,7 @@ unconstrained fn __get_num_padding_chars_var<let InputElements: u32>(
  *        Each Base64 value is 6 bits. This method will produce a byte array where data is concatenated so that there are no sparse bits
  *        (e.g. encoding 4 ASCII values produces 24 bits of Base64 data = 3 bytes of output data)
  **/
-fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let UseURLTable: u1>(
+fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: bool, let UseURLTable: bool>(
     input: [u8; InputElements],
 ) -> [u8; OutputBytes] {
     let rem = OutputBytes % 3;
@@ -177,7 +177,7 @@ fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let UseURLT
                 let offset = i * BASE64_ELEMENTS_PER_CHUNK + j;
                 let input_byte: u8 = input[offset];
                 let index = input_byte as u32;
-                let decoded = if UseURLTable == 1 {
+                let decoded = if UseURLTable {
                     BASE64_DECODE_BE_URL_TABLE[index]
                 } else {
                     BASE64_DECODE_BE_TABLE[index]
@@ -215,7 +215,7 @@ fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let UseURLT
             let offset = base64_offset + j;
             let input_byte: u8 = input[offset];
             let index = input_byte as u32;
-            let decoded = if UseURLTable == 1 {
+            let decoded = if UseURLTable {
                 BASE64_DECODE_BE_URL_TABLE[index]
             } else {
                 BASE64_DECODE_BE_TABLE[index]
@@ -253,11 +253,11 @@ fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let UseURLT
  *        Each Base64 value is 6 bits. This method will produce a byte array where data is concatenated so that there are no sparse bits
  *        (e.g. encoding 4 ASCII values produces 24 bits of Base64 data = 3 bytes of output data)
  **/
-pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let UseURLTable: u1>(
+pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: bool, let UseURLTable: bool>(
     input: BoundedVec<u8, InputElements>,
 ) -> BoundedVec<u8, OutputBytes> {
     // We don't know how many padding bytes the input string contains - we use an unconstrained fn to return a *claim* that we will later validate
-    let (has_first_padding_byte_claim, has_second_padding_byte_claim) = if (Pad == 1) {
+    let (has_first_padding_byte_claim, has_second_padding_byte_claim) = if (Pad) {
         // Safety: get claims about whether the bytes input[input.len() - 2] and input[input.len() - 1] are padding chars
         // we validate this later on by requiring these characters equal BASE64_PADDING_CHAR by looking up BASE64_DECODE_BE_VAR_TABLE
         unsafe {
@@ -268,7 +268,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
     };
 
     // num_padding_chars is a claim that depends on has_first_padding_byte_claim and has_second_padding_byte_claim being correct
-    let num_padding_chars: u32 = if Pad == 1 {
+    let num_padding_chars: u32 = if Pad {
         has_first_padding_byte_claim as u32 + has_second_padding_byte_claim as u32
     } else {
         0
@@ -300,7 +300,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                 let input_byte = input[offset];
 
                 let mut decode_index: Field = 0;
-                if Pad == 1 {
+                if Pad {
                     let mut might_be_second_padding_char = 0;
                     let mut might_be_first_padding_char = 0;
                     // These if statements should not cost extra gates as the condition is known at compile time
@@ -342,7 +342,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
                 }
                 decode_index.assert_max_bit_size::<32>();
                 let decode_index = decode_index as u32;
-                let decoded = if UseURLTable == 1 {
+                let decoded = if UseURLTable {
                     BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
                 } else {
                     BASE64_DECODE_BE_VAR_TABLE[decode_index]
@@ -379,7 +379,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
             let input_byte = input[offset];
 
             let mut decode_index: Field = 0;
-            if Pad == 1 {
+            if Pad {
                 let mut might_be_second_padding_char = 0;
                 let mut might_be_first_padding_char = 0;
                 // These if statements should not cost extra gates as the condition is known at compile time
@@ -412,7 +412,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
             decode_index.assert_max_bit_size::<32>();
             let decode_index = decode_index as u32;
 
-            let decoded = if UseURLTable == 1 {
+            let decoded = if UseURLTable {
                 BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
             } else {
                 BASE64_DECODE_BE_VAR_TABLE[decode_index]
@@ -442,7 +442,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u1, let
         }
     }
 
-    if Pad == 1 {
+    if Pad {
         assert(input_length % 4 == 0, "base64 encoded strings must be a multiple of 4 bytes");
     }
 

--- a/src/decoder.nr
+++ b/src/decoder.nr
@@ -14,13 +14,13 @@ pub mod Base64DecodeBE {
     pub fn decode<let InputBytes: u32, let OutputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; OutputBytes] {
-        crate::decoder::decode::<InputBytes, OutputBytes, true, false>(input)
+        crate::decoder::decode::<InputBytes, OutputBytes, 1_u8, 0_u8>(input)
     }
 
     pub fn decode_var<let MaxInputBytes: u32, let MaxOutputBytes: u32>(
         input: BoundedVec<u8, MaxInputBytes>,
     ) -> BoundedVec<u8, MaxOutputBytes> {
-        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, true, false>(input)
+        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, 1_u8, 0_u8>(input)
     }
 }
 
@@ -30,13 +30,13 @@ pub mod Base64DecodeBENoPad {
     pub fn decode<let InputBytes: u32, let OutputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; OutputBytes] {
-        crate::decoder::decode::<InputBytes, OutputBytes, false, false>(input)
+        crate::decoder::decode::<InputBytes, OutputBytes, 0_u8, 0_u8>(input)
     }
 
     pub fn decode_var<let MaxInputBytes: u32, let MaxOutputBytes: u32>(
         input: BoundedVec<u8, MaxInputBytes>,
     ) -> BoundedVec<u8, MaxOutputBytes> {
-        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, false, false>(input)
+        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, 0_u8, 0_u8>(input)
     }
 }
 
@@ -46,13 +46,13 @@ pub mod Base64DecodeBEUrlSafe {
     pub fn decode<let InputBytes: u32, let OutputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; OutputBytes] {
-        crate::decoder::decode::<InputBytes, OutputBytes, false, true>(input)
+        crate::decoder::decode::<InputBytes, OutputBytes, 0_u8, 1_u8>(input)
     }
 
     pub fn decode_var<let MaxInputBytes: u32, let MaxOutputBytes: u32>(
         input: BoundedVec<u8, MaxInputBytes>,
     ) -> BoundedVec<u8, MaxOutputBytes> {
-        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, false, true>(input)
+        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, 0_u8, 1_u8>(input)
     }
 }
 
@@ -62,13 +62,13 @@ pub mod Base64DecodeBEUrlSafeWithPad {
     pub fn decode<let InputBytes: u32, let OutputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; OutputBytes] {
-        crate::decoder::decode::<InputBytes, OutputBytes, true, true>(input)
+        crate::decoder::decode::<InputBytes, OutputBytes, 1_u8, 1_u8>(input)
     }
 
     pub fn decode_var<let MaxInputBytes: u32, let MaxOutputBytes: u32>(
         input: BoundedVec<u8, MaxInputBytes>,
     ) -> BoundedVec<u8, MaxOutputBytes> {
-        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, true, true>(input)
+        crate::decoder::decode_var::<MaxInputBytes, MaxOutputBytes, 1_u8, 1_u8>(input)
     }
 }
 
@@ -111,9 +111,11 @@ unconstrained fn __get_num_padding_chars_var<let InputElements: u32>(
  *        Each Base64 value is 6 bits. This method will produce a byte array where data is concatenated so that there are no sparse bits
  *        (e.g. encoding 4 ASCII values produces 24 bits of Base64 data = 3 bytes of output data)
  **/
-fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: bool, let UseURLTable: bool>(
+fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: u8, let UseURLTable: u8>(
     input: [u8; InputElements],
 ) -> [u8; OutputBytes] {
+    std::static_assert(Pad < 2, "Pad must be 0 or 1");
+    std::static_assert(UseURLTable < 2, "UseURLTable must be 0 or 1");
     let rem = OutputBytes % 3;
     // Calculate the number of padding characters and the length of the input without padding
     let num_padding_chars = if rem == 1 {
@@ -177,7 +179,7 @@ fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: bool, let UseUR
                 let offset = i * BASE64_ELEMENTS_PER_CHUNK + j;
                 let input_byte: u8 = input[offset];
                 let index = input_byte as u32;
-                let decoded = if UseURLTable {
+                let decoded = if UseURLTable == 1 {
                     BASE64_DECODE_BE_URL_TABLE[index]
                 } else {
                     BASE64_DECODE_BE_TABLE[index]
@@ -215,7 +217,7 @@ fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: bool, let UseUR
             let offset = base64_offset + j;
             let input_byte: u8 = input[offset];
             let index = input_byte as u32;
-            let decoded = if UseURLTable {
+            let decoded = if UseURLTable == 1 {
                 BASE64_DECODE_BE_URL_TABLE[index]
             } else {
                 BASE64_DECODE_BE_TABLE[index]
@@ -253,11 +255,13 @@ fn decode<let InputElements: u32, let OutputBytes: u32, let Pad: bool, let UseUR
  *        Each Base64 value is 6 bits. This method will produce a byte array where data is concatenated so that there are no sparse bits
  *        (e.g. encoding 4 ASCII values produces 24 bits of Base64 data = 3 bytes of output data)
  **/
-pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: bool, let UseURLTable: bool>(
+pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: u8, let UseURLTable: u8>(
     input: BoundedVec<u8, InputElements>,
 ) -> BoundedVec<u8, OutputBytes> {
+    std::static_assert(Pad < 2, "Pad must be 0 or 1");
+    std::static_assert(UseURLTable < 2, "UseURLTable must be 0 or 1");
     // We don't know how many padding bytes the input string contains - we use an unconstrained fn to return a *claim* that we will later validate
-    let (has_first_padding_byte_claim, has_second_padding_byte_claim) = if (Pad) {
+    let (has_first_padding_byte_claim, has_second_padding_byte_claim) = if (Pad == 1) {
         // Safety: get claims about whether the bytes input[input.len() - 2] and input[input.len() - 1] are padding chars
         // we validate this later on by requiring these characters equal BASE64_PADDING_CHAR by looking up BASE64_DECODE_BE_VAR_TABLE
         unsafe {
@@ -268,7 +272,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: bool, l
     };
 
     // num_padding_chars is a claim that depends on has_first_padding_byte_claim and has_second_padding_byte_claim being correct
-    let num_padding_chars: u32 = if Pad {
+    let num_padding_chars: u32 = if Pad == 1 {
         has_first_padding_byte_claim as u32 + has_second_padding_byte_claim as u32
     } else {
         0
@@ -300,7 +304,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: bool, l
                 let input_byte = input[offset];
 
                 let mut decode_index: Field = 0;
-                if Pad {
+                if Pad == 1 {
                     let mut might_be_second_padding_char = 0;
                     let mut might_be_first_padding_char = 0;
                     // These if statements should not cost extra gates as the condition is known at compile time
@@ -342,7 +346,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: bool, l
                 }
                 decode_index.assert_max_bit_size::<32>();
                 let decode_index = decode_index as u32;
-                let decoded = if UseURLTable {
+                let decoded = if UseURLTable == 1 {
                     BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
                 } else {
                     BASE64_DECODE_BE_VAR_TABLE[decode_index]
@@ -379,7 +383,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: bool, l
             let input_byte = input[offset];
 
             let mut decode_index: Field = 0;
-            if Pad {
+            if Pad == 1 {
                 let mut might_be_second_padding_char = 0;
                 let mut might_be_first_padding_char = 0;
                 // These if statements should not cost extra gates as the condition is known at compile time
@@ -412,7 +416,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: bool, l
             decode_index.assert_max_bit_size::<32>();
             let decode_index = decode_index as u32;
 
-            let decoded = if UseURLTable {
+            let decoded = if UseURLTable == 1 {
                 BASE64_DECODE_BE_URL_VAR_TABLE[decode_index]
             } else {
                 BASE64_DECODE_BE_VAR_TABLE[decode_index]
@@ -442,7 +446,7 @@ pub fn decode_var<let InputElements: u32, let OutputBytes: u32, let Pad: bool, l
         }
     }
 
-    if Pad {
+    if Pad == 1 {
         assert(input_length % 4 == 0, "base64 encoded strings must be a multiple of 4 bytes");
     }
 

--- a/src/encoder.nr
+++ b/src/encoder.nr
@@ -19,13 +19,13 @@ pub mod Base64EncodeBE {
     pub fn encode<let InputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; ((InputBytes * 8) / 6) + (((InputBytes % 3) % 2) * 3) + (((InputBytes % 3) / 2) * 2)] {
-        crate::encoder::encode::<InputBytes, false, 1>(input)
+        crate::encoder::encode::<InputBytes, 0_u8, 1>(input)
     }
 
     pub fn encode_var<let MAX_INPUT_LEN: u32>(
         input: BoundedVec<u8, MAX_INPUT_LEN>,
     ) -> BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * 3) + (((MAX_INPUT_LEN % 3) / 2) * 2)> {
-        crate::encoder::encode_var::<_, false, 1>(input)
+        crate::encoder::encode_var::<_, 0_u8, 1>(input)
     }
 }
 
@@ -35,13 +35,13 @@ pub mod Base64EncodeBENoPad {
     pub fn encode<let InputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; ((InputBytes * 8) / 6) + (((InputBytes % 3) % 2)) + (((InputBytes % 3) / 2))] {
-        crate::encoder::encode::<InputBytes, false, 0>(input)
+        crate::encoder::encode::<InputBytes, 0_u8, 0>(input)
     }
 
     pub fn encode_var<let MAX_INPUT_LEN: u32>(
         input: BoundedVec<u8, MAX_INPUT_LEN>,
     ) -> BoundedVec<u8, (((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2)) + (((MAX_INPUT_LEN % 3) / 2)))> {
-        crate::encoder::encode_var::<_, false, 0>(input)
+        crate::encoder::encode_var::<_, 0_u8, 0>(input)
     }
 }
 
@@ -51,13 +51,13 @@ pub mod Base64EncodeBEUrlSafe {
     pub fn encode<let InputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; ((InputBytes * 8) / 6) + (((InputBytes % 3) % 2)) + (((InputBytes % 3) / 2))] {
-        crate::encoder::encode::<_, true, 0>(input)
+        crate::encoder::encode::<_, 1_u8, 0>(input)
     }
 
     pub fn encode_var<let MAX_INPUT_LEN: u32>(
         input: BoundedVec<u8, MAX_INPUT_LEN>,
     ) -> BoundedVec<u8, (((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2)) + (((MAX_INPUT_LEN % 3) / 2)))> {
-        crate::encoder::encode_var::<_, true, 0>(input)
+        crate::encoder::encode_var::<_, 1_u8, 0>(input)
     }
 }
 
@@ -67,12 +67,12 @@ pub mod Base64EncodeBEUrlSafeWithPad {
     pub fn encode<let InputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; ((InputBytes * 8) / 6) + (((InputBytes % 3) % 2) * 3) + (((InputBytes % 3) / 2) * 2)] {
-        crate::encoder::encode::<_, true, 1>(input)
+        crate::encoder::encode::<_, 1_u8, 1>(input)
     }
     pub fn encode_var<let MAX_INPUT_LEN: u32>(
         input: BoundedVec<u8, MAX_INPUT_LEN>,
     ) -> BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * 3) + (((MAX_INPUT_LEN % 3) / 2) * 2)> {
-        crate::encoder::encode_var::<_, true, 1>(input)
+        crate::encoder::encode_var::<_, 1_u8, 1>(input)
     }
 }
 
@@ -81,14 +81,15 @@ pub mod Base64EncodeBEUrlSafeWithPad {
  * @tparam InputElements: The size of the array being encoded
  * @tparam UseUrlTable: are we encoding using the URL and Filename Safe Alphabet, or standard Base64 Alphabet? 
  **/
-fn encode_elements<let InputElements: u32, let UseUrlTable: bool>(
+fn encode_elements<let InputElements: u32, let UseUrlTable: u8>(
     input: [u8; InputElements],
 ) -> [u8; InputElements] {
+    std::static_assert(UseUrlTable < 2, "UseUrlTable must be 0 or 1");
     let mut result: [u8; InputElements] = [0; InputElements];
 
     for i in 0..InputElements {
         let index = input[i] as u32;
-        let token: u8 = if UseUrlTable {
+        let token: u8 = if UseUrlTable == 1 {
             BASE64URL_ENCODE_BE_TABLE[index]
         } else {
             BASE64_ENCODE_BE_TABLE[index]
@@ -102,9 +103,10 @@ fn encode_elements<let InputElements: u32, let UseUrlTable: bool>(
 /**
  * @brief Encode a variable-length ASCII string into Base64 values
  **/
-fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: bool, let HasPadding: u32>(
+fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u8, let HasPadding: u32>(
     input: BoundedVec<u8, MAX_INPUT_LEN>,
     ) -> BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))> {
+    std::static_assert(UseURLTable < 2, "UseURLTable must be 0 or 1");
     assert((HasPadding == 0) | (HasPadding == 1), "invalid HasPadding parameter");
     // The max number of output Base64 values can be derived from the max input size
     let mut result_arr
@@ -205,7 +207,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: bool, let HasPadding: u32
         let encoding_index = encoding_index as u32;
 
         // Note: this `if` condition is known at compile time so should not incur additional constraints
-        let token: u8 = if UseURLTable {
+        let token: u8 = if UseURLTable == 1 {
             BASE64_ENCODE_BE_VAR_TABLE[encoding_index]
         } else {
             BASE64URL_ENCODE_BE_VAR_TABLE[encoding_index]
@@ -303,9 +305,10 @@ fn split_into_six_bit_chunks<let InputBytes: u32, let OutputElements: u32, let H
     result
 }
 
-fn encode<let InputBytes: u32, let UseUrlTable: bool, let UsePadding: u32>(
+fn encode<let InputBytes: u32, let UseUrlTable: u8, let UsePadding: u32>(
     input: [u8; InputBytes],
     ) -> [u8; ((InputBytes * 8) / 6) + (((InputBytes % 3) % 2) * (1 + UsePadding * 2)) + (((InputBytes % 3) / 2) * (1 + UsePadding))] {
+    std::static_assert(UseUrlTable < 2, "UseUrlTable must be 0 or 1");
     assert((UsePadding == 0 as u32) | (UsePadding == 1 as u32), "UsePadding must be 0 or 1");
     let mut result = crate::encoder::encode_elements::<_, UseUrlTable>(
         crate::encoder::split_into_six_bit_chunks::<_, _, UsePadding>(input),
@@ -344,7 +347,7 @@ fn test_encode_elements() {
         22, 19, 36, 0, 33, 18, 25, 57, 62, 22, 4, 17, 33, 10, 33, 23, 45, 37, 20,
     ];
 
-    let ascii_result = crate::encoder::encode_elements::<_, false>(input);
+    let ascii_result = crate::encoder::encode_elements::<_, 0_u8>(input);
 
     assert(ascii_result == ascii_expected);
 }
@@ -546,7 +549,7 @@ fn test_encode() {
 #[test]
 fn test_base64_encode_slash() {
     let input: [u8; 1] = [63]; // '/' in Base64
-    let result: [u8; 1] = crate::encoder::encode_elements::<_, false>(input);
+    let result: [u8; 1] = crate::encoder::encode_elements::<_, 0_u8>(input);
 
     // Should map to '/' in ASCII, which is 47
     assert(result[0] == 47);

--- a/src/encoder.nr
+++ b/src/encoder.nr
@@ -19,13 +19,13 @@ pub mod Base64EncodeBE {
     pub fn encode<let InputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; ((InputBytes * 8) / 6) + (((InputBytes % 3) % 2) * 3) + (((InputBytes % 3) / 2) * 2)] {
-        crate::encoder::encode::<InputBytes, 0_u1, 1>(input)
+        crate::encoder::encode::<InputBytes, false, 1>(input)
     }
 
     pub fn encode_var<let MAX_INPUT_LEN: u32>(
         input: BoundedVec<u8, MAX_INPUT_LEN>,
     ) -> BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * 3) + (((MAX_INPUT_LEN % 3) / 2) * 2)> {
-        crate::encoder::encode_var::<_, 0_u1, 1>(input)
+        crate::encoder::encode_var::<_, false, 1>(input)
     }
 }
 
@@ -35,13 +35,13 @@ pub mod Base64EncodeBENoPad {
     pub fn encode<let InputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; ((InputBytes * 8) / 6) + (((InputBytes % 3) % 2)) + (((InputBytes % 3) / 2))] {
-        crate::encoder::encode::<InputBytes, 0_u1, 0>(input)
+        crate::encoder::encode::<InputBytes, false, 0>(input)
     }
 
     pub fn encode_var<let MAX_INPUT_LEN: u32>(
         input: BoundedVec<u8, MAX_INPUT_LEN>,
     ) -> BoundedVec<u8, (((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2)) + (((MAX_INPUT_LEN % 3) / 2)))> {
-        crate::encoder::encode_var::<_, 0_u1, 0>(input)
+        crate::encoder::encode_var::<_, false, 0>(input)
     }
 }
 
@@ -51,13 +51,13 @@ pub mod Base64EncodeBEUrlSafe {
     pub fn encode<let InputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; ((InputBytes * 8) / 6) + (((InputBytes % 3) % 2)) + (((InputBytes % 3) / 2))] {
-        crate::encoder::encode::<_, 1_u1, 0>(input)
+        crate::encoder::encode::<_, true, 0>(input)
     }
 
     pub fn encode_var<let MAX_INPUT_LEN: u32>(
         input: BoundedVec<u8, MAX_INPUT_LEN>,
     ) -> BoundedVec<u8, (((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2)) + (((MAX_INPUT_LEN % 3) / 2)))> {
-        crate::encoder::encode_var::<_, 1_u1, 0>(input)
+        crate::encoder::encode_var::<_, true, 0>(input)
     }
 }
 
@@ -67,12 +67,12 @@ pub mod Base64EncodeBEUrlSafeWithPad {
     pub fn encode<let InputBytes: u32>(
         input: [u8; InputBytes],
     ) -> [u8; ((InputBytes * 8) / 6) + (((InputBytes % 3) % 2) * 3) + (((InputBytes % 3) / 2) * 2)] {
-        crate::encoder::encode::<_, 1_u1, 1>(input)
+        crate::encoder::encode::<_, true, 1>(input)
     }
     pub fn encode_var<let MAX_INPUT_LEN: u32>(
         input: BoundedVec<u8, MAX_INPUT_LEN>,
     ) -> BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * 3) + (((MAX_INPUT_LEN % 3) / 2) * 2)> {
-        crate::encoder::encode_var::<_, 1_u1, 1>(input)
+        crate::encoder::encode_var::<_, true, 1>(input)
     }
 }
 
@@ -81,14 +81,14 @@ pub mod Base64EncodeBEUrlSafeWithPad {
  * @tparam InputElements: The size of the array being encoded
  * @tparam UseUrlTable: are we encoding using the URL and Filename Safe Alphabet, or standard Base64 Alphabet? 
  **/
-fn encode_elements<let InputElements: u32, let UseUrlTable: u1>(
+fn encode_elements<let InputElements: u32, let UseUrlTable: bool>(
     input: [u8; InputElements],
 ) -> [u8; InputElements] {
     let mut result: [u8; InputElements] = [0; InputElements];
 
     for i in 0..InputElements {
         let index = input[i] as u32;
-        let token: u8 = if UseUrlTable == 1 {
+        let token: u8 = if UseUrlTable {
             BASE64URL_ENCODE_BE_TABLE[index]
         } else {
             BASE64_ENCODE_BE_TABLE[index]
@@ -102,7 +102,7 @@ fn encode_elements<let InputElements: u32, let UseUrlTable: u1>(
 /**
  * @brief Encode a variable-length ASCII string into Base64 values
  **/
-fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
+fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: bool, let HasPadding: u32>(
     input: BoundedVec<u8, MAX_INPUT_LEN>,
     ) -> BoundedVec<u8, ((MAX_INPUT_LEN * 8) / 6) + (((MAX_INPUT_LEN % 3) % 2) * (1 + HasPadding * 2)) + (((MAX_INPUT_LEN % 3) / 2) * (1 + HasPadding))> {
     assert((HasPadding == 0) | (HasPadding == 1), "invalid HasPadding parameter");
@@ -205,7 +205,7 @@ fn encode_var<let MAX_INPUT_LEN: u32, let UseURLTable: u1, let HasPadding: u32>(
         let encoding_index = encoding_index as u32;
 
         // Note: this `if` condition is known at compile time so should not incur additional constraints
-        let token: u8 = if UseURLTable == 1 {
+        let token: u8 = if UseURLTable {
             BASE64_ENCODE_BE_VAR_TABLE[encoding_index]
         } else {
             BASE64URL_ENCODE_BE_VAR_TABLE[encoding_index]
@@ -303,7 +303,7 @@ fn split_into_six_bit_chunks<let InputBytes: u32, let OutputElements: u32, let H
     result
 }
 
-fn encode<let InputBytes: u32, let UseUrlTable: u1, let UsePadding: u32>(
+fn encode<let InputBytes: u32, let UseUrlTable: bool, let UsePadding: u32>(
     input: [u8; InputBytes],
     ) -> [u8; ((InputBytes * 8) / 6) + (((InputBytes % 3) % 2) * (1 + UsePadding * 2)) + (((InputBytes % 3) / 2) * (1 + UsePadding))] {
     assert((UsePadding == 0 as u32) | (UsePadding == 1 as u32), "UsePadding must be 0 or 1");
@@ -344,7 +344,7 @@ fn test_encode_elements() {
         22, 19, 36, 0, 33, 18, 25, 57, 62, 22, 4, 17, 33, 10, 33, 23, 45, 37, 20,
     ];
 
-    let ascii_result = crate::encoder::encode_elements::<_, 0_u1>(input);
+    let ascii_result = crate::encoder::encode_elements::<_, false>(input);
 
     assert(ascii_result == ascii_expected);
 }
@@ -546,7 +546,7 @@ fn test_encode() {
 #[test]
 fn test_base64_encode_slash() {
     let input: [u8; 1] = [63]; // '/' in Base64
-    let result: [u8; 1] = crate::encoder::encode_elements::<_, 0_u1>(input);
+    let result: [u8; 1] = crate::encoder::encode_elements::<_, false>(input);
 
     // Should map to '/' in ASCII, which is 47
     assert(result[0] == 47);


### PR DESCRIPTION
# Description

## Problem\*

Resolves breakages post https://github.com/noir-lang/noir/pull/11753

## Summary\*



## Additional Context



# PR Checklist\*

- [ ] I have tested the changes locally.
- [ ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
